### PR TITLE
fix(hermes-agent): bump lark-oapi to 1.6.8 to fix broken Feishu channel in 2026.7.20

### DIFF
--- a/hermes-agent/Dockerfile
+++ b/hermes-agent/Dockerfile
@@ -16,7 +16,7 @@ ENV HERMES_DASHBOARD=1 \
     PATH=/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN chmod -R u+w /opt/hermes/.venv && \
-    uv pip install --no-cache-dir "lark-oapi==1.5.3" "qrcode==7.4.2" && \
+    uv pip install --no-cache-dir "lark-oapi==1.6.8" "qrcode==7.4.2" && \
     chown -R root:root /opt/hermes/.venv && \
     chmod -R a+rX /opt/hermes/.venv && \
     chmod -R a-w /opt/hermes/.venv


### PR DESCRIPTION
## Problem

The `hermes-agent` image pins `lark-oapi==1.5.3`, but Hermes Agent **2026.7.20** (upstream `3ef6bbd2`) declares `feishu = ["lark-oapi==1.6.8", "qrcode==7.4.2"]` in its `pyproject.toml` and locks 1.6.8 in `uv.lock`.

The 2026.7.20 Feishu adapter passes the `extra_ua_tags` keyword argument to `lark_oapi.ws.Client`, which does not exist in 1.5.3. As a result, the Feishu channel of the current `1panel/hermes-agent:2026.7.20` image fails to start out of the box:

```
File "/opt/hermes/plugins/platforms/feishu/adapter.py", line 4768, in _connect_websocket
    self._ws_client = FeishuWSClient(
        app_id=self._app_id,
        ...
        extra_ua_tags=["channel"],
    )
TypeError: Client.__init__() got an unexpected keyword argument 'extra_ua_tags'
WARNING gateway.run: ✗ feishu failed to connect
```

Reproduced on fnOS (飞牛 EVO 4) with 1Panel App Store deployment; the container starts but the Feishu channel cannot connect.

Since the image makes `/opt/hermes/.venv` read-only, users cannot fix this at runtime — rebuilding the image is the only workaround.

## Fix

Bump the pinned `lark-oapi` version from 1.5.3 to 1.6.8 to match the version locked by Hermes upstream. Verified on the affected deployment: with 1.6.8 installed, the Feishu channel connects normally.

Note: 1.6.8 is a strict superset of 1.5.3 for the APIs Hermes uses (compared the API surface of both versions against Hermes' imports), so this bump carries no regression risk for existing functionality.

## Suggestion

Longer term, consider deriving the pinned version from the Hermes upstream `uv.lock` at build time instead of hardcoding it, so future Hermes bumps don't silently break bundled channel dependencies.
